### PR TITLE
Line do not shows by default, this cause an invisible GanttVLine

### DIFF
--- a/lib/JpGraph/src/jpgraph.php
+++ b/lib/JpGraph/src/jpgraph.php
@@ -3164,7 +3164,7 @@ class Graph {
 // Description: Holds properties for a line
 //===================================================
 class LineProperty {
-    public $iWeight=1, $iColor='black', $iStyle='solid', $iShow=false;
+    public $iWeight=1, $iColor='black', $iStyle='solid', $iShow=true;
 
     function __construct($aWeight=1,$aColor='black',$aStyle='solid') {
         $this->iWeight = $aWeight;


### PR DESCRIPTION
the property iLine in GanttVLine is private, there is no way to modify this property from a user point of view
