### PR TITLE
Fixed JpGraph source for case sensitive filesystems; fixed exception name

### DIFF
--- a/lib/JpGraph.php
+++ b/lib/JpGraph.php
@@ -5,18 +5,18 @@ class JpGraph {
     static  $modules = array();
     static function load(){
         if(self::$loaded !== true){
-            include_once __DIR__.'/jpgraph/src/jpgraph.php';
+            include_once __DIR__.'/JpGraph/src/jpgraph.php';
             self::$loaded = true ;
         }
     }
     static function module($moduleName){
         self::load();
         if(!in_array($moduleName,self::$modules)){
-            $path = __DIR__.'/jpgraph/src/jpgraph_'.$moduleName.'.php' ;
+            $path = __DIR__.'/JpGraph/src/jpgraph_'.$moduleName.'.php' ;
             if(file_exists($path)){
                 include_once $path ;
             }else{
-                throw new ModuleNotFoundException('The JpGraphs\'s module "'.$moduleName.'" does not exist');
+                throw new \InvalidArgumentException('The JpGraphs\'s module "'.$moduleName.'" does not exist');
             }
         }
     }


### PR DESCRIPTION
The old source written in lowercase only worked on case-insensitive filesystems (such as HFS+ on Mac OS X), but didn't on case sensitive ones (like ext3 on Linux); also the "ModuleNotFoundException" doesn't exist, so reverted to use an InvalidArgumentException from SPL